### PR TITLE
Workaround for a bug preventing AvatarFav from updating properly

### DIFF
--- a/mod/updatesAndDependencies/AvatarFavUpdater.cs
+++ b/mod/updatesAndDependencies/AvatarFavUpdater.cs
@@ -133,6 +133,8 @@ namespace VRCTools
             {
                 VRCUiPopupManagerUtils.ShowPopup("AvatarFav Updater", "Saving AvatarFav");
                 VRCModLogger.Log("[AvatarFavUpdater] Saving file");
+                if (File.Exists(avatarfavPath))
+                    File.Delete(avatarfavPath);
                 File.WriteAllBytes(avatarfavPath, vrctoolsDownload.bytes);
 
                 VRCModLogger.Log("[AvatarFavUpdater] Showing restart dialog");


### PR DESCRIPTION
I suspected that the AvatarFav file can't be written to if it already exists, so this snippet will check if it exists and remove it, before saving the new version into the same directory.